### PR TITLE
Feature/input variants

### DIFF
--- a/include/daggle.h.in
+++ b/include/daggle.h.in
@@ -67,7 +67,7 @@ typedef enum daggle_input_behavior_e {
 	DAGGLE_INPUT_BEHAVIOR_ACQUIRE, // Caller acquires ownership, mutable
 } daggle_input_behavior_t;
 
-// Note: ACQUIRE becomes CLONE, unless the input is the sole link to the output.
+// Note: data got via reference input ports remain valid for the node and its subtasks.
 
 // ### PLUGIN DEFINITIONS
 

--- a/include/daggle.h.in
+++ b/include/daggle.h.in
@@ -62,32 +62,13 @@ typedef enum daggle_port_variant_e {
 	DAGGLE_PORT_PARAMETER,
 } daggle_port_variant_t;
 
-typedef enum daggle_input_variant_e {
-	DAGGLE_INPUT_IMMUTABLE_REFERENCE, // Reference to value, freed after use
-	DAGGLE_INPUT_IMMUTABLE_COPY, // Copy of value, freed after use
-	DAGGLE_INPUT_MUTABLE_REFERENCE, // Reference to value, is
-									// DAGGLE_INPUT_MUTABLE_COPY unless this is
-									// only port, user must free or pass forward
-	DAGGLE_INPUT_MUTABLE_COPY, // Copy of value, user must free or pass forward
-} daggle_input_variant_t; // When in doubt, use
-						  // DAGGLE_INPUT_IMMUTABLE_REFERENCE.
+typedef enum daggle_input_behavior_e {
+	DAGGLE_INPUT_BEHAVIOR_REFERENCE, // Immutable reference, no ownership
+	DAGGLE_INPUT_BEHAVIOR_CLONE, // Mutable copy, caller owns
+	DAGGLE_INPUT_BEHAVIOR_ACQUIRE, // Caller acquires ownership
+} daggle_input_behavior_t;
 
-// MUTABLE_REFERENCE becomes MUTABLE_COPY, unless there is exactly one
-// connection, and the connection is MUTABLE_REFERENCE
-
-// Note: MUTABLE_REFERENCE resets the value of the source port
-
-// IMMUTABLE_REFERENCE -> IMMUTABLE_REFERENCE
-// IMMUTABLE_REFERENCE + IMMUTABLE_REFERENCE -> IMMUTABLE_REFERENCE +
-// IMMUTABLE_REFERENCE IMMUTABLE_COPY + IMMUTABLE_REFERENCE -> IMMUTABLE_COPY +
-// IMMUTABLE_REFERENCE
-
-// MUTABLE_REFERENCE -> MUTABLE_REFERENCE
-// MUTABLE_REFERENCE + X -> MUTABLE_COPY + X
-// MUTABLE_REFERENCE + MUTABLE_REFERENCE -> MUTABLE_COPY + MUTABLE_COPY
-
-// IMMUTABLE_REFERENCE + MUTABLE_COPY -> IMMUTABLE_REFERENCE + MUTABLE_COPY
-// IMMUTABLE_REFERENCE + MUTABLE_REFERENCE -> IMMUTABLE_REFERENCE + MUTABLE_COPY
+// Note: ACQUIRE becomes CLONE, unless the input is the sole link to the output.
 
 // ### PLUGIN DEFINITIONS
 
@@ -350,7 +331,7 @@ daggle_node_get_graph(daggle_node_h node, daggle_graph_h* out_graph);
 
 DAGGLE_API daggle_error_code_t
 daggle_node_declare_input(daggle_node_h node, const char* port_name,
-	daggle_input_variant_t variant,
+	daggle_input_behavior_t input_behavior,
 	daggle_default_value_generator_fn default_value_gen);
 
 DAGGLE_API daggle_error_code_t

--- a/include/daggle.h.in
+++ b/include/daggle.h.in
@@ -64,8 +64,7 @@ typedef enum daggle_port_variant_e {
 
 typedef enum daggle_input_behavior_e {
 	DAGGLE_INPUT_BEHAVIOR_REFERENCE, // Immutable reference, no ownership
-	DAGGLE_INPUT_BEHAVIOR_CLONE, // Mutable copy, caller owns
-	DAGGLE_INPUT_BEHAVIOR_ACQUIRE, // Caller acquires ownership
+	DAGGLE_INPUT_BEHAVIOR_ACQUIRE, // Caller acquires ownership, mutable
 } daggle_input_behavior_t;
 
 // Note: ACQUIRE becomes CLONE, unless the input is the sole link to the output.

--- a/plugins/core/src/nodes/math.c
+++ b/plugins/core/src/nodes/math.c
@@ -118,10 +118,10 @@ DEFAULT_VALUE_GENERATOR(math_gdv_operation, int32_t, 0, INT_TYPE)
 void
 math(daggle_node_h handle)
 {
-	daggle_node_declare_input(handle, "first", DAGGLE_INPUT_BEHAVIOR_REFERENCE,
+	daggle_node_declare_input(handle, "first", DAGGLE_INPUT_BEHAVIOR_ACQUIRE,
 		math_gdv_first);
 	daggle_node_declare_input(handle, "second",
-		DAGGLE_INPUT_BEHAVIOR_REFERENCE, math_gdv_second);
+		DAGGLE_INPUT_BEHAVIOR_ACQUIRE, math_gdv_second);
 	daggle_node_declare_parameter(handle, "operation", math_gdv_operation);
 	daggle_node_declare_output(handle, "result");
 	daggle_node_declare_task(handle, math_impl);

--- a/plugins/core/src/nodes/math.c
+++ b/plugins/core/src/nodes/math.c
@@ -118,10 +118,10 @@ DEFAULT_VALUE_GENERATOR(math_gdv_operation, int32_t, 0, INT_TYPE)
 void
 math(daggle_node_h handle)
 {
-	daggle_node_declare_input(handle, "first", DAGGLE_INPUT_IMMUTABLE_REFERENCE,
+	daggle_node_declare_input(handle, "first", DAGGLE_INPUT_BEHAVIOR_REFERENCE,
 		math_gdv_first);
 	daggle_node_declare_input(handle, "second",
-		DAGGLE_INPUT_IMMUTABLE_REFERENCE, math_gdv_second);
+		DAGGLE_INPUT_BEHAVIOR_REFERENCE, math_gdv_second);
 	daggle_node_declare_parameter(handle, "operation", math_gdv_operation);
 	daggle_node_declare_output(handle, "result");
 	daggle_node_declare_task(handle, math_impl);

--- a/plugins/core/src/nodes/output.c
+++ b/plugins/core/src/nodes/output.c
@@ -52,9 +52,9 @@ output_gdv_message(void** out_data, const char** out_type)
 void
 output(daggle_node_h handle)
 {
-	daggle_node_declare_input(handle, "value", DAGGLE_INPUT_IMMUTABLE_REFERENCE,
+	daggle_node_declare_input(handle, "value", DAGGLE_INPUT_BEHAVIOR_REFERENCE,
 		output_gdv_value);
 	daggle_node_declare_input(handle, "message",
-		DAGGLE_INPUT_IMMUTABLE_REFERENCE, output_gdv_message);
+		DAGGLE_INPUT_BEHAVIOR_REFERENCE, output_gdv_message);
 	daggle_node_declare_task(handle, output_impl);
 }

--- a/plugins/core/src/nodes/output.c
+++ b/plugins/core/src/nodes/output.c
@@ -1,5 +1,6 @@
 #include "nodes/output.h"
 
+#include "daggle/daggle.h"
 #include "node_utils.h"
 #include "stdio.h"
 #include "stdlib.h"
@@ -52,7 +53,7 @@ output_gdv_message(void** out_data, const char** out_type)
 void
 output(daggle_node_h handle)
 {
-	daggle_node_declare_input(handle, "value", DAGGLE_INPUT_BEHAVIOR_REFERENCE,
+	daggle_node_declare_input(handle, "value", DAGGLE_INPUT_BEHAVIOR_ACQUIRE,
 		output_gdv_value);
 	daggle_node_declare_input(handle, "message",
 		DAGGLE_INPUT_BEHAVIOR_REFERENCE, output_gdv_message);

--- a/plugins/graph/main.c
+++ b/plugins/graph/main.c
@@ -117,7 +117,7 @@ input_bridge(daggle_node_h handle)
 	daggle_node_declare_parameter(handle, "name", bridge_name_default_value);
 	daggle_node_declare_output(handle, "value");
 
-	daggle_node_declare_input(handle, "_bridge", DAGGLE_INPUT_MUTABLE_COPY,
+	daggle_node_declare_input(handle, "_bridge", DAGGLE_INPUT_BEHAVIOR_ACQUIRE,
 		null_default_value);
 
 	daggle_node_declare_task(handle, input_bridge_impl);
@@ -127,7 +127,7 @@ void
 output_bridge(daggle_node_h handle)
 {
 	daggle_node_declare_parameter(handle, "name", bridge_name_default_value);
-	daggle_node_declare_input(handle, "value", DAGGLE_INPUT_MUTABLE_COPY,
+	daggle_node_declare_input(handle, "value", DAGGLE_INPUT_BEHAVIOR_ACQUIRE,
 		null_default_value);
 
 	daggle_node_declare_output(handle, "_bridge");
@@ -307,7 +307,7 @@ graph_invoker_declare_graph_bridges(daggle_node_h handle, daggle_graph_h graph)
 
 		if (is_input) {
 			daggle_node_declare_input(handle, name_value,
-				DAGGLE_INPUT_MUTABLE_COPY, null_default_value);
+				DAGGLE_INPUT_BEHAVIOR_ACQUIRE, null_default_value);
 		} else {
 			daggle_node_declare_output(handle, name_value);
 		}

--- a/private/ports.h
+++ b/private/ports.h
@@ -12,7 +12,7 @@ typedef struct port_variant_output_s {
 
 typedef struct port_variant_input_s {
 	daggle_port_h link;
-	daggle_input_variant_t variant;
+	daggle_input_behavior_t behavior;
 } port_variant_input_t;
 
 typedef struct port_variant_parameter_s {

--- a/private/ports.h
+++ b/private/ports.h
@@ -3,16 +3,20 @@
 #include "data_container.h"
 #include "resource_container.h"
 #include "utility/dynamic_array.h"
+#include "stdatomic.h"
+#include "stdint.h"
 
 #include <daggle/daggle.h>
 
 typedef struct port_variant_output_s {
 	dynamic_array_t links;
+	_Atomic(uint32_t) num_pending_accesses;
 } port_variant_output_t;
 
 typedef struct port_variant_input_s {
 	daggle_port_h link;
 	daggle_input_behavior_t behavior;
+	bool has_spent_access;
 } port_variant_input_t;
 
 typedef struct port_variant_parameter_s {

--- a/private/serialization.h
+++ b/private/serialization.h
@@ -42,7 +42,6 @@ typedef enum port_variant_1_e {
 
 typedef enum input_behavior_1_e {
 	REFERENCE,
-	CLONE,
 	ACQUIRE
 } input_behavior_1_t;
 

--- a/private/serialization.h
+++ b/private/serialization.h
@@ -40,12 +40,11 @@ typedef enum port_variant_1_e {
 	PARAMETER,
 } port_variant_1_t;
 
-typedef enum input_variant_1_e {
-	IMMUTABLE_REFERENCE,
-	IMMUTABLE_COPY,
-	MUTABLE_REFERENCE,
-	MUTABLE_COPY
-} input_variant_1_t;
+typedef enum input_behavior_1_e {
+	REFERENCE,
+	CLONE,
+	ACQUIRE
+} input_behavior_1_t;
 
 typedef struct port_entry_1_s {
 	uint64_t name_stoff;
@@ -53,6 +52,6 @@ typedef struct port_entry_1_s {
 	uint64_t data_dtoff; // max if unset
 	port_variant_1_t port_variant;
 	union {
-		input_variant_1_t input;
+		input_behavior_1_t input;
 	} port_specific;
 } port_entry_1_t;

--- a/src/api_node.c
+++ b/src/api_node.c
@@ -9,7 +9,7 @@
 
 daggle_error_code_t
 prv_node_declare_port(daggle_port_variant_t variant, daggle_node_h node,
-	const char* port_name, daggle_input_variant_t input_variant,
+	const char* port_name, daggle_input_behavior_t input_behavior,
 	daggle_default_value_generator_fn default_value_gen)
 {
 	ASSERT_PARAMETER(node);
@@ -49,7 +49,7 @@ prv_node_declare_port(daggle_port_variant_t variant, daggle_node_h node,
 	new_port.value = default_value_cnt;
 
 	if (variant == DAGGLE_PORT_INPUT) {
-		new_port.variant.input.variant = input_variant;
+		new_port.variant.input.behavior = input_behavior;
 	}
 
 	// Set the created port as declared.
@@ -60,7 +60,7 @@ prv_node_declare_port(daggle_port_variant_t variant, daggle_node_h node,
 
 daggle_error_code_t
 daggle_node_declare_input(daggle_node_h node, const char* port_name,
-	daggle_input_variant_t variant,
+	daggle_input_behavior_t input_behavior,
 	daggle_default_value_generator_fn default_value_gen)
 {
 	REQUIRE_PARAMETER(node);
@@ -68,7 +68,7 @@ daggle_node_declare_input(daggle_node_h node, const char* port_name,
 	REQUIRE_PARAMETER(default_value_gen);
 
 	RETURN_STATUS(prv_node_declare_port(DAGGLE_PORT_INPUT, node, port_name,
-		variant, default_value_gen));
+		input_behavior, default_value_gen));
 }
 
 daggle_error_code_t

--- a/src/api_port.c
+++ b/src/api_port.c
@@ -333,10 +333,9 @@ prv_input_get_value(port_t* port, void** out_data)
 			*out_data = link->value.data;
 			link->value.data = NULL;
 			link->value.info = NULL;
-		} 
-		// Otherwise use the cloning behavior.
-	case DAGGLE_INPUT_BEHAVIOR_CLONE:
-		prv_port_get_value_as_copy(target_port, out_data);
+		} else {
+			prv_port_get_value_as_copy(target_port, out_data);
+		}
 		break;
 	}
 }

--- a/src/api_port.c
+++ b/src/api_port.c
@@ -3,6 +3,7 @@
 #include "node.h"
 #include "ports.h"
 #include "resource_container.h"
+#include "utility/log_macro.h"
 #include "utility/return_macro.h"
 
 #include <daggle/daggle.h>
@@ -322,25 +323,19 @@ prv_input_get_value(port_t* port, void** out_data)
 	// Determine which port to use as the source.
 	port_t* target_port = link ? link : port;
 
-	switch (port->variant.input.variant) {
-	case DAGGLE_INPUT_IMMUTABLE_REFERENCE:
+	switch (port->variant.input.behavior) {
+	case DAGGLE_INPUT_BEHAVIOR_REFERENCE:
 		prv_port_get_value_as_reference(target_port, out_data);
 		break;
-	case DAGGLE_INPUT_IMMUTABLE_COPY:
-		LOG(LOG_TAG_WARN,
-			"Currently DAGGLE_INPUT_IMMUTABLE_COPY inputs will leak; caller "
-			"should free the received data, or prefer "
-			"DAGGLE_INPUT_MUTABLE_COPY");
-		prv_port_get_value_as_copy(target_port, out_data);
-		break;
-	case DAGGLE_INPUT_MUTABLE_REFERENCE:
-		if (!link || link->variant.output.links.length == 1) {
-			// Steal the data
+	case DAGGLE_INPUT_BEHAVIOR_ACQUIRE:
+		// Acquire is available only if port is linked, and it is the only link from the output
+		if (link && link->variant.output.links.length == 1) {
 			*out_data = link->value.data;
 			link->value.data = NULL;
 			link->value.info = NULL;
-		} // Otherwise will act like mutable copy
-	case DAGGLE_INPUT_MUTABLE_COPY:
+		} 
+		// Otherwise use the cloning behavior.
+	case DAGGLE_INPUT_BEHAVIOR_CLONE:
 		prv_port_get_value_as_copy(target_port, out_data);
 		break;
 	}

--- a/src/api_tasks.c
+++ b/src/api_tasks.c
@@ -13,7 +13,8 @@ prv_sink_closure(void* context)
 void
 prv_sink_dispose(void* context)
 {
-	task_free((task_t*)context);
+	task_t* task = context;
+	task_free(task);
 }
 
 typedef struct prv_node_task_wrapper_ctx {

--- a/src/ports.c
+++ b/src/ports.c
@@ -48,7 +48,7 @@ port_init(daggle_node_h node, const char* port_name,
 
 	if (variant == DAGGLE_PORT_INPUT) {
 		port.variant.input.link = NULL;
-		port.variant.input.variant = DAGGLE_INPUT_IMMUTABLE_REFERENCE;
+		port.variant.input.behavior = DAGGLE_INPUT_BEHAVIOR_REFERENCE;
 	} else if (variant == DAGGLE_PORT_OUTPUT) {
 		dynamic_array_init(0, sizeof(port_t*), &port.variant.output.links);
 	}

--- a/src/serialization.c
+++ b/src/serialization.c
@@ -47,8 +47,6 @@ prv_input_behavior_daggle_to_1(daggle_input_behavior_t variant)
 		LOG_FMT(LOG_TAG_ERROR, "Unknown input variant %u", variant);
 	case DAGGLE_INPUT_BEHAVIOR_REFERENCE:
 		return REFERENCE;
-	case DAGGLE_INPUT_BEHAVIOR_CLONE:
-		return CLONE;
 	case DAGGLE_INPUT_BEHAVIOR_ACQUIRE:
 		return ACQUIRE;
 	}
@@ -62,8 +60,6 @@ prv_input_behavior_1_to_daggle(input_behavior_1_t variant)
 		LOG_FMT(LOG_TAG_ERROR, "Unknown input variant %u", variant);
 	case REFERENCE:
 		return DAGGLE_INPUT_BEHAVIOR_REFERENCE;
-	case CLONE:
-		return DAGGLE_INPUT_BEHAVIOR_CLONE;
 	case ACQUIRE:
 		return DAGGLE_INPUT_BEHAVIOR_ACQUIRE;
 	}

--- a/src/serialization.c
+++ b/src/serialization.c
@@ -39,37 +39,33 @@ prv_port_variant_1_to_daggle(port_variant_1_t variant)
 	}
 }
 
-input_variant_1_t
-prv_input_variant_daggle_to_1(daggle_input_variant_t variant)
+input_behavior_1_t
+prv_input_behavior_daggle_to_1(daggle_input_behavior_t variant)
 {
 	switch (variant) {
 	default:
 		LOG_FMT(LOG_TAG_ERROR, "Unknown input variant %u", variant);
-	case DAGGLE_INPUT_IMMUTABLE_REFERENCE:
-		return IMMUTABLE_REFERENCE;
-	case DAGGLE_INPUT_IMMUTABLE_COPY:
-		return IMMUTABLE_COPY;
-	case DAGGLE_INPUT_MUTABLE_REFERENCE:
-		return MUTABLE_REFERENCE;
-	case DAGGLE_INPUT_MUTABLE_COPY:
-		return MUTABLE_COPY;
+	case DAGGLE_INPUT_BEHAVIOR_REFERENCE:
+		return REFERENCE;
+	case DAGGLE_INPUT_BEHAVIOR_CLONE:
+		return CLONE;
+	case DAGGLE_INPUT_BEHAVIOR_ACQUIRE:
+		return ACQUIRE;
 	}
 }
 
-daggle_input_variant_t
-prv_input_variant_1_to_daggle(input_variant_1_t variant)
+daggle_input_behavior_t
+prv_input_behavior_1_to_daggle(input_behavior_1_t variant)
 {
 	switch (variant) {
 	default:
 		LOG_FMT(LOG_TAG_ERROR, "Unknown input variant %u", variant);
-	case IMMUTABLE_REFERENCE:
-		return DAGGLE_INPUT_IMMUTABLE_REFERENCE;
-	case IMMUTABLE_COPY:
-		return DAGGLE_INPUT_IMMUTABLE_COPY;
-	case MUTABLE_REFERENCE:
-		return DAGGLE_INPUT_MUTABLE_REFERENCE;
-	case MUTABLE_COPY:
-		return DAGGLE_INPUT_MUTABLE_COPY;
+	case REFERENCE:
+		return DAGGLE_INPUT_BEHAVIOR_REFERENCE;
+	case CLONE:
+		return DAGGLE_INPUT_BEHAVIOR_CLONE;
+	case ACQUIRE:
+		return DAGGLE_INPUT_BEHAVIOR_ACQUIRE;
 	}
 }
 
@@ -244,7 +240,7 @@ prv_port_serialize_and_push(port_t* port, graph_t* graph,
 	// For input ports, set the input variant, and link if it has one
 	if (port->port_variant == DAGGLE_PORT_INPUT) {
 		port_entry.port_specific.input
-			= prv_input_variant_daggle_to_1(port->variant.input.variant);
+			= prv_input_behavior_daggle_to_1(port->variant.input.behavior);
 
 		if (port->variant.input.link) {
 			port_entry.edge_ptidx
@@ -383,11 +379,11 @@ prv_deserialize_port(daggle_instance_h instance, node_t* node,
 			printf("  - Link: port[%llu]\n", port_entry->edge_ptidx);
 		}
 
-		daggle_input_variant_t input_variant;
-		input_variant
-			= prv_input_variant_1_to_daggle(port_entry->port_specific.input);
+		daggle_input_behavior_t input_behavior;
+		input_behavior
+			= prv_input_behavior_1_to_daggle(port_entry->port_specific.input);
 
-		port_element->variant.input.variant = input_variant;
+		port_element->variant.input.behavior = input_behavior;
 	}
 
 	// If port has data deserialize it and set the port value

--- a/src/serialization.c
+++ b/src/serialization.c
@@ -367,8 +367,7 @@ prv_deserialize_port(daggle_instance_h instance, node_t* node,
 
 	// Deserialize input port variant
 	if (port_entry->port_variant == INPUT) {
-		const char* ivarnames[] = { "IMMUTABLE_REFERENCE", "IMMUTABLE_COPY",
-			"MUTABLE_REFERENCE", "MUTABLE_COPY" };
+		const char* ivarnames[] = { "REFERENCE", "ACQUIRE" };
 		printf("  - Input: %s\n", ivarnames[port_entry->port_specific.input]);
 
 		if (port_entry->edge_ptidx != UINT64_MAX) {


### PR DESCRIPTION
Improve input port behavior. Reduced the number of input port variant options from 4 to 2. Data-acquiring input ports will now be able to acquire data, as long as every other port has finished using the data. 